### PR TITLE
Bug-1127491: Fixed sunburst chart issues. Removed duplicate data from input JSON

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -155,44 +155,53 @@
       }
     }
 
-    function renderSunburst(rawData) {
-      function convert(source, target, basePath) {
-        for (let key in source) {
-          let path = basePath ? basePath + ' > ' + key : key;
-          if (!key.match(/^\$/)) {
-            target.children = target.children || [];
-            const child = {
-              name: path
-            };
-            target.children.push(child);
-            convert(source[key], child, path);
-          } else {
-            target.value = source.$count || 0;
-          }
-        }
-        if (!target.children) {
-          target.value = source.$count || 0;
+    function convert(source, target, basePath) {
+      for (let key in source) {
+        let path = basePath ? basePath + ' > ' + key : key;
+        if (!key.match(/^\$/)) {
+          target.children = target.children || [];
+          const child = {
+            name: path
+          };
+          target.children.push(child);
+          convert(source[key], child, path);
         } else {
-          target.children.push({
-            name: basePath,
-            value: source.$count
-          });
+          target.value = source.$count || 0;
         }
       }
+      if (!target.children) {
+        target.value = source.$count || 0;
+      }
+      else if ($scope.config.vizType === 'treemap') {
+       target.children.push({
+         name: basePath,
+         value: source.$count
+       });
+      }
+    }
+
+    function renderSunburst(rawData) {
       const data = {
         children: []
       };
       convert(rawData, data, '');
       data.children = data.children.filter(children => children.name !== "");
       $scope.option = {
+        textStyle: {
+          overflow: 'break'
+        },
         series: {
           type: 'sunburst',
           height: "80%",
           width: "80%",
           data: data.children,
           label: {
-            rotate: 'tangential', // 'radial'
-            formatter: '{b}\n\n{c}'
+            rotate: 'tangential', // 'tangential', // 'radial'
+            formatter: '{b}\n\n{c}',
+            //position: 'inside',
+            overflow: 'breakAll', // 'brake',
+            ellipsis: '...'
+            // align: 'center'
           },
           labelLayout: { hideOverlap: true },
           // emphasis: {
@@ -212,29 +221,6 @@
     }
 
     function renderTreemapData(rawData) {
-      function convert(source, target, basePath) {
-        for (let key in source) {
-          let path = basePath ? basePath + ' > ' + key : key;
-          if (!key.match(/^\$/)) {
-            target.children = target.children || [];
-            const child = {
-              name: path
-            };
-            target.children.push(child);
-            convert(source[key], child, path);
-          } else {
-            target.value = source.$count || 0;
-          }
-        }
-        if (!target.children) {
-          target.value = source.$count || 0;
-        } else {
-          target.children.push({
-            name: basePath,
-            value: source.$count
-          });
-        }
-      }
       const data = {
         children: []
       };
@@ -298,7 +284,7 @@
           window.define = define;
           initializeChart();
           $scope.processing = false;
-        }, 5000);
+        }, 3000);
       });
     }
 


### PR DESCRIPTION
Root Cause:
Issue 1: The system is not showing correct data and duplicated slices are coming in the view.
Issue 2: The system takes around 5-8 sec to load or render the widget.

Fix Details:
Issue1: 
Data formation was the same as that of Treemap data. But in the case of Sunburst required to remove duplicate children's entries from the JSON. Fixed parser and added check for Treemap type while adding duplicate entries in the children's array.

Issue2:
The reason is due to the AMD Loader. A few libraries are having conflicts due to the loader.js file which is the part of platform. Libraries should load in the sequence to work properly. To handle this added 5 sec delay for loading widget echart libraries. This delay is now reduced to 3 sec. Going forward will handle this in the platform code.

Mantis:
https://mantis.fortinet.com/bug_view_page.php?bug_id=1127491
https://mantis.fortinet.com/bug_view_page.php?bug_id=1127399

<img width="1719" alt="Screenshot 2025-02-19 at 10 40 05 PM" src="https://github.com/user-attachments/assets/52ce9672-5ca8-4283-9c9d-03bcc338ddd7" />
