### PR TITLE
PMDB#33958: Lookup support added for Sunburst/Treemap

### DIFF
--- a/widget/edit.html
+++ b/widget/edit.html
@@ -111,7 +111,7 @@
                             </span>
                         </label>
                         <select name="picklistField-{{ $index }}" id="picklistField-{{ $index }}" class="form-control"
-                            data-ng-options="field.name as field.title for field in fieldsArray | filter: filterByFieldType(['picklist']) | orderBy: 'title'"
+                            data-ng-options="{ name: field.name, type: field.type } as field.title for field in fieldsArray | filter: filterByFieldType(['picklist', 'lookup']) | orderBy: 'title' track by field.name"
                             data-ng-model="config.sunTree.mappingLevel[$index]" required>
                             <option value="">Select an Option</option>
                         </select>

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -8,9 +8,9 @@
     .module('cybersponse')
     .controller('dataVisualization100Ctrl', dataVisualization100Ctrl);
 
-  dataVisualization100Ctrl.$inject = ['$scope', 'widgetUtilityService', 'config', '$timeout', 'dataVisualizationService', 'Entity', 'dataVisualization_VIZ_MAP_TYPES', '$rootScope'];
+  dataVisualization100Ctrl.$inject = ['$scope', 'widgetUtilityService', 'config', '$timeout', 'dataVisualizationService', 'Entity', 'dataVisualization_VIZ_MAP_TYPES', '$rootScope', '_'];
 
-  function dataVisualization100Ctrl($scope, widgetUtilityService, config, $timeout, dataVisualizationService, Entity, dataVisualization_VIZ_MAP_TYPES, $rootScope) {
+  function dataVisualization100Ctrl($scope, widgetUtilityService, config, $timeout, dataVisualizationService, Entity, dataVisualization_VIZ_MAP_TYPES, $rootScope, _) {
 
     $scope.config = config;
     var _config = angular.copy(config);
@@ -131,8 +131,9 @@
          formedData = data;
       } else {
         // Form Data for Map Rendering
+        let levelKeys = _.pluck($scope.config.sunTree.mappingLevel, 'name');
         formedData = inputJSON.mapData.reduce((obj, record) => {
-          obj = _createNestedObject(obj, record, $scope.config.sunTree.mappingLevel);
+          obj = _createNestedObject(obj, record, levelKeys);
 
           return obj;
         }, {});
@@ -404,12 +405,22 @@
           },
           grid: {
             height: '50%',
-            top: '10%'
+            top: '10%',
+            left: '15%'
           },
           xAxis: {
             type: 'category',
             data: heatMapConfig.xAxis,
             splitArea: {
+              show: true
+            },
+            axisLabel: {
+              rotate: '45',
+              width: '50',
+              overflow: 'truncate',
+              ellipsis: '..'
+            },
+            tooltip: {
               show: true
             }
           },
@@ -417,6 +428,15 @@
             type: 'category',
             data: heatMapConfig.yAxis,
             splitArea: {
+              show: true
+            },
+            axisLabel: {
+              rotate: '45',
+              width: '50',
+              overflow: 'truncate',
+              ellipsis: '..'
+            },
+            tooltip: {
               show: true
             }
           },

--- a/widget/view.html
+++ b/widget/view.html
@@ -13,6 +13,7 @@
             data-ng-class="(page === 'dashboard' || page === 'reporting') ? 'widget-dashboard-actions-width' : 'widget-actions-width'">
             <span class="fa btn widget-action-icon btn-sm pull-right" data-ng-click="collapsed = !collapsed"
                 data-ng-class="{'fa-caret-up': !collapsed, 'fa-caret-down': collapsed}"></span>
+            <span class="fa btn btn-sm fa-refresh pull-right" data-ng-click="init()"></span>
         </div>
     </div>
     <div data-ng-hide="collapsed">

--- a/widget/view.html
+++ b/widget/view.html
@@ -13,7 +13,6 @@
             data-ng-class="(page === 'dashboard' || page === 'reporting') ? 'widget-dashboard-actions-width' : 'widget-actions-width'">
             <span class="fa btn widget-action-icon btn-sm pull-right" data-ng-click="collapsed = !collapsed"
                 data-ng-class="{'fa-caret-up': !collapsed, 'fa-caret-down': collapsed}"></span>
-            <span class="fa btn btn-sm fa-refresh pull-right" data-ng-click="init()"></span>
         </div>
     </div>
     <div data-ng-hide="collapsed">

--- a/widget/widgetAssets/js/dataVisualization.service.js
+++ b/widget/widgetAssets/js/dataVisualization.service.js
@@ -75,31 +75,35 @@
                 case dataVisualization_VIZ_MAP_TYPES.SUNBURST:
                 case dataVisualization_VIZ_MAP_TYPES.TREE_MAP: 
                 {
-                    queryObject.sort.push({
-                        field: config.sunTree.mappingLevel[0] + '.orderIndex',
-                        direction: 'ASC'
-                    });
+                    if (['picklist'].indexOf(config.sunTree.mappingLevel[0].type) > -1) {
+                        queryObject.sort.push({
+                            field: config.sunTree.mappingLevel[0].name + '.orderIndex',
+                            direction: 'ASC'
+                        });
+                        queryObject.aggregates.push({
+                            operator: 'groupby',
+                            alias: 'orderIndex',
+                            field: config.sunTree.mappingLevel[0].name + '.orderIndex'
+                        });
+                    }
                     queryObject.aggregates.push({
                         operator: 'count',
                         field: '*',
                         alias: 'total'
                     });
-                    queryObject.aggregates.push({
-                        operator: 'groupby',
-                        alias: 'orderIndex',
-                        field: config.sunTree.mappingLevel[0] + '.orderIndex'
-                    });
                     (config.sunTree.mappingLevel).forEach((level, index) => {
                         queryObject.aggregates.push({
                             operator: 'groupby',
-                            alias: level,
-                            field: level + '.itemValue'
+                            alias: level.name,
+                            field: level.name + (['picklist'].indexOf(level.type) > -1 ? '.itemValue' : '.name')
                         });
-                        queryObject.aggregates.push({
-                            operator: 'groupby',
-                            alias: 'l' + index + 'Color',
-                            field: level + '.color'
-                        });
+                        if (['picklist'].indexOf(config.sunTree.mappingLevel[0].type) > -1) {
+                            queryObject.aggregates.push({
+                                operator: 'groupby',
+                                alias: 'l' + index + 'Color',
+                                field: level.name + '.color'
+                            });
+                        }
                     });
                 }
                     break;


### PR DESCRIPTION
## Description:
* Sunburst/Treepmap lookup support added. Hence, the config was updated for both charts.

Sunburst/Treemap:
```
{
    "sunTree": {
        "mappingLevel": [
            {
                "name": "tenant",
                "type": "lookup"
            },
            {
                "name": "type",
                "type": "picklist"
            },
            {
                "name": "status",
                "type": "picklist"
            }
        ]
    }
}
```

* Heatmap: x & y axis label rotated by 45deg and truncated with 50px width.

## PMDB:
33958

## Screenshot
![Screenshot 2025-03-04 at 5 45 50 PM](https://github.com/user-attachments/assets/55d81635-da53-42ef-bc9c-5489d832ebd2)

![Screenshot 2025-03-04 at 5 46 07 PM](https://github.com/user-attachments/assets/ee3ed040-330b-43bf-a62c-8737f7fe2625)

![Screenshot 2025-03-04 at 5 46 20 PM](https://github.com/user-attachments/assets/a9a8a202-1538-4692-950f-3aeea0599802)
