### PR TITLE
Visualization getting divided between two pages in the report

### DIFF
--- a/widget/view.html
+++ b/widget/view.html
@@ -21,7 +21,7 @@
                 <div data-ng-show="hideChartCanvas" class="watermark grid-margin ng-binding width-100pt" aria-hidden="false">
                     {{ viewWidgetVars.MSG_NO_RESULTS }}
                 </div>
-                <div data-ng-show="!hideChartCanvas" id="eChart-{{ config.wid }}" style="position: relative; max-height:700px;"></div>
+                <div data-ng-show="!hideChartCanvas" class="page-break-avoid" id="eChart-{{ config.wid }}" style="position: relative; max-height:700px;"></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Description
### Issue: 
* Visualization getting divided between two pages in the report

### Fix: 
* Added `page-break-avoid` class to avoid chart to split into 2 on page break

## Mantis: 
1131396


## Screenshot of Report:
<img width="824" alt="Screenshot 2025-03-19 at 8 29 43 PM" src="https://github.com/user-attachments/assets/140caeb2-2cc7-4006-bd10-b54e0c071006" />
