### PR TITLE
BUG-1139221: When the user click on last level and system moves to the module then memory leak is occurring Description

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -670,6 +670,10 @@
       });
     }
 
+    $scope.$on('$destroy', function() {
+      $scope.myChart && echarts.dispose($scope.myChart);
+    });
+
     $scope.init();
   }
 })();


### PR DESCRIPTION
## Description:
### Issue:
* When the user clicks on last level and the system moves to the module then memory leak occurs

### Fix:
* Remove the widget once not in use

## Mantis/PMDB:
PMDB: 33958
BugID: 1139221
