### PR TITLE
Word Cloud: Words which are colored in dark blue and purple are not visible

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -442,11 +442,9 @@
             fontFamily: 'sans-serif',
             fontWeight: 'bold',
             color: function () {
-              return 'rgb(' + [
-                Math.round(Math.random() * 160),
-                Math.round(Math.random() * 160),
-                Math.round(Math.random() * 160)
-              ].join(',') + ')';
+              return $scope.themeId === 'light'
+                ? `rgb(${Math.round(Math.random() * 160)}, ${Math.round(Math.random() * 160)}, ${Math.round(Math.random() * 160)})`
+                : `rgb(${200 + Math.random() * 55}, ${200 + Math.random() * 55}, ${200 + Math.random() * 55})`;
             }
           },
           data: rawData


### PR DESCRIPTION
## Description:
### Issue:
* Word Cloud: Words which are colored in dark blue and purple are not visible

### Fix
* If the product theme is set to dark/space then Word cloud will show light shade colors for words

## Mantis/PMDB:
PMDB: 33958
Mantis: 1137671

## Screenshot:
![Screenshot 2025-03-25 at 6 01 53 PM](https://github.com/user-attachments/assets/4bd95abe-3515-4b3a-9288-b7543d5c7f75)
![Screenshot 2025-03-25 at 6 02 28 PM](https://github.com/user-attachments/assets/dc364cd6-15ba-43ae-ac1e-7316e3cea1e8)
