### PR TITLE
Bug-1129648: Adjusted category size to ensure visibility in Treemap by artificially managing small values.

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -341,7 +341,7 @@
      * @param {Array} data - The array of category data objects to be normalized.
      * @returns {Array} - The modified data with adjusted category sizes.
      */
-    function normalizeCategorySize(data) {
+    function _normalizeCategorySize(data) {
       if (!data || data.length === 0 || !data[0].children) return;
 
       data[0].name = resourceName;
@@ -381,7 +381,7 @@
         data[0].children = rawData.children;
       }
       // Handling rendering of small values in the chart
-      normalizeCategorySize(data);
+      _normalizeCategorySize(data);
       $scope.myChart.setOption(
         ($scope.option = {
           tooltip: {

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -268,6 +268,12 @@
       return basicTemplateArray.join('');
     }
 
+    /**
+     * Processes raw hierarchical data to generate a structured format for Sunburst chart visualization.
+     * This method organizes the input data into a hierarchy suitable for rendering in a Sunburst chart.
+     * 
+     * @param {Array} rawData - The input raw dataset containing hierarchical categories and values.
+     */
     function renderSunburst(rawData) {
       const data = {
         children: []
@@ -313,46 +319,67 @@
           label: {
             rotate: 'tangential', // 'tangential', // 'radial'
             formatter: '{b}\n\n{c}',
-            //position: 'inside',
             width: 30,
             overflow: 'truncate', // 'brake',
             ellipsis: '..',
             minMargin: 5,
-            // color: ('light' === $scope.themeId) ? '#000' : '#fff',
             minAngle: '10' // If the data is less than 10 deg then it doesn't show text
           },
           labelLayout: { hideOverlap: true },
-          // emphasis: {
-          //   label: {
-          //     formatter: '\n{b}\n\n{c}'
-          //   }
-          // },
-          // downplay: {
-          //   label: {
-          //     formatter: '\n{b}\n\n{c}'
-          //   }
-          // }
         }
       };
 
       $scope.option && $scope.myChart.setOption($scope.option);
     }
 
+    /**
+     * Normalizes the category size for small values to ensure better rendering in a Treemap.
+     * This function adjusts the data to make small categories more visually distinguishable.
+     * 
+     * @param {Array} data - The array of category data objects to be normalized.
+     * @returns {Array} - The modified data with adjusted category sizes.
+     */
+    function normalizeCategorySize(data) {
+      if (!data || data.length === 0 || !data[0].children) return;
+
+      data[0].name = resourceName;
+
+      // Calculate the total base value in a single pass
+      let baseValue = data[0].children.reduce((sum, child) => sum + child.value, 0);
+      data[0].value = baseValue;
+
+      let minValue = Math.round((baseValue * 2) / 100);
+      data[0].children.forEach(child => {
+        if (child.value < minValue) {
+          child.value = minValue;
+        }
+      });
+    }
+
+    /**
+     * Transforms raw hierarchical data into a structured format suitable for Treemap rendering.
+     * This method processes the input data, calculates necessary properties, and ensures 
+     * correct hierarchical representation for visualization.
+     *
+     * @param {Array} rawData - The input raw dataset containing hierarchical categories and values.
+     */
     function renderTreemapData(rawData) {
-      const data = {
+      const data = [{
         children: []
-      };
+      }];
       let levelLabels;
       if (dataVisualization_VIZ_TYPES.ACROSS === _config.moduleType) {
-        convert(rawData, data, '');
-        data.children = data.children.filter(children => children.name !== '');
+        convert(rawData, data[0], '');
+        data[0].children = data[0].children.filter(children => children.name !== '');
         let mappingArray = _.pluck($scope.config.sunTree.mappingLevel, 'name');
         levelLabels = _.pluck(_.filter($scope.fields, function(field) {
           return (mappingArray).indexOf(field.name) > -1;
         }).sort((a, b) => mappingArray.indexOf(a.name) - mappingArray.indexOf(b.name)), 'title');
       } else {
-        data.children = rawData.children;
+        data[0].children = rawData.children;
       }
+      // Handling rendering of small values in the chart
+      normalizeCategorySize(data);
       $scope.myChart.setOption(
         ($scope.option = {
           tooltip: {
@@ -385,10 +412,11 @@
             {
               name: 'Base',
               type: 'treemap',
-              visibleMin: 300,
+              visibleMin: 0,
+              visualMin: 1,
               roam: false,
-              data: data.children,
-              leafDepth: 2,
+              data: data,
+              leafDepth: 3,
               levels: [
                 {
                   itemStyle: {

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -255,7 +255,9 @@
             <div>`];
       if (levelValues.length > 0) {
         levelValues.forEach(function (value, index) {
-          basicTemplateArray.push(`${levelLabels[index]}: ${value}<br/>`);
+          if (value !== resourceName) {
+            basicTemplateArray.push(`${levelLabels[index]}: ${value}<br/>`);
+          }
         });
       }
       basicTemplateArray.push(`</div></div>`);


### PR DESCRIPTION
**Issue:**
The critical severity type is not visible in the visualization if around 1 lakh alerts are present.

Steps to Reproduce:
1. Add a Data Visualization widget on the dashboard and take Level 1 as Severity, Level 2 as Type, Level 3 as State
2. Make sure you have a large data set of record present (~1 lakh)
3. There should be 15 records of Critical severity
4. Observe the chart

**Solution:**

The issue mentioned occurs in ECharts Treemap because Critical severity has significantly fewer records (15) than the other categories. Since Treemap sizes sections based on proportional values, very small values may not get enough space to be displayed.

Here user can apply the filter to view or observe specific category details in the visualization chart.
The configuration parameters provided by eCharts for Treemap are not rendering those small values, so to handle the same for Treemap we have added handling to adjust category size to ensure visibility of small value categories by artificially managing small values.
Along with that we also handled the display of correct data in the tooltip on hovering category on the Treemap.

**Note:**
The data format for Sunburst is different and custom handling is not provided for now. Users can set filters to view categories on the map for now.

**Mantis/PMDB:**
PMDB: 33958
Mantis: 1129648

**Screenshots**
![Screenshot 2025-03-26 at 12 19 03 PM](https://github.com/user-attachments/assets/7427c4bb-4fff-43ac-8e9b-7ec711642b32)


