### PR TITLE
bug/1138223: Heatmap-Slider text is overlapping with X-axis values

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -627,6 +627,7 @@
           calculable: true,
           orient: 'horizontal',
           left: 'center',
+          top: '75%',
           bottom: '15%',
           inRange: {
             color: [
@@ -685,7 +686,7 @@
       window.AMDLoader = {};
       window.define = {};
       $scope.hideChartCanvas = false;
-      dataVisualizationService.loadJs(['https://cdnjs.cloudflare.com/ajax/libs/echarts/5.6.0/echarts.min.js', 'https://cdn.jsdelivr.net/npm/echarts-wordcloud/dist/echarts-wordcloud.min.js', 'https://cdn.jsdelivr.net/npm/echarts-gl/dist/echarts-gl.min.js']).then(function () {
+      dataVisualizationService.loadJs(['https://cdnjs.cloudflare.com/ajax/libs/echarts/5.6.0/echarts.min.js', 'https://cdn.jsdelivr.net/npm/echarts-wordcloud/dist/echarts-wordcloud.min.js']).then(function () {
         $timeout(function() {
           window.AMDLoader = loader;
           window.define = define;


### PR DESCRIPTION
## Description
### Issue:
* Heatmap-Slider text is overlapping with X-axis values

### Fix:
* Visual Map Top set to 75%, which keeps visualMap below chart

## Mantis/PMDB:
PMDB: 33958
Mantis: 1138223

## Screenshot:
<img width="421" alt="Screenshot 2025-03-26 at 4 29 45 PM" src="https://github.com/user-attachments/assets/b290f15f-deb3-4f53-8f87-3488c55f43c7" />

<img width="1646" alt="Screenshot 2025-03-26 at 4 29 33 PM" src="https://github.com/user-attachments/assets/6c8d31cb-674c-4fb2-93a7-9217467a05fb" />
