### PR TITLE
Background color of chart must match the Platform theme color

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -292,6 +292,7 @@
         data.children = rawData.children;
       }
       $scope.option = {
+        backgroundColor: 'transparent',
         textStyle: {
           overflow: 'break'
         },
@@ -384,6 +385,7 @@
       _normalizeCategorySize(data);
       $scope.myChart.setOption(
         ($scope.option = {
+          backgroundColor: 'transparent',
           tooltip: {
             formatter: function (info) {
               if (dataVisualization_VIZ_TYPES.ACROSS === _config.moduleType) {
@@ -456,6 +458,7 @@
     function renderWordCloud(rawData) {
       // Configure the chart
       $scope.option = {
+        backgroundColor: 'transparent',
         title: {
           text: dataVisualization_VIZ_TYPES.SINGLE === _config.moduleType ? '' : resourceName,
           left: 'center'
@@ -581,6 +584,7 @@
       }
 
       $scope.option = {
+        backgroundColor: 'transparent',
         tooltip: {
           position: 'top'
         },


### PR DESCRIPTION
## Description
### Issue:
* The background color of the chart must match the Platform theme color

### Fix:
* background color set to transparent for all the available charts

## Mantis/PMDB:
* PMDB: 33958
* Mantis: 1143776

## Screenshot:
![Screenshot 2025-04-02 at 5 36 16 PM](https://github.com/user-attachments/assets/3c9552dd-cb7f-46ce-add6-48ce32eb8541)
