### PR TITLE
bug/1146049: Sorted datetime for heatmap chart & removed wordcloud title

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -35,20 +35,12 @@
         textColor: 'light' === $scope.themeId ? '#000' : '#FFF',
         maskColor: 'light' === $scope.themeId ? 'rgba(255, 255, 255, 0.8)' : 'rgba(51, 59, 71, 1)',
         zlevel: 0,
-      
-        // Font size. Available since `v4.8.0`.
         fontSize: 12,
-        // Show an animated "spinner" or not. Available since `v4.8.0`.
         showSpinner: true,
-        // Radius of the "spinner". Available since `v4.8.0`.
         spinnerRadius: 10,
-        // Line width of the "spinner". Available since `v4.8.0`.
         lineWidth: 5,
-        // Font thick weight. Available since `v5.0.1`.
         fontWeight: 'normal',
-        // Font style. Available since `v5.0.1`.
         fontStyle: 'normal',
-        // Font family. Available since `v5.0.1`.
         fontFamily: 'sans-serif'
       });
     }
@@ -459,10 +451,6 @@
       // Configure the chart
       $scope.option = {
         backgroundColor: 'transparent',
-        title: {
-          text: dataVisualization_VIZ_TYPES.SINGLE === _config.moduleType ? '' : resourceName,
-          left: 'center'
-        },
         tooltip: {
           show: true
         },

--- a/widget/widgetAssets/js/dataVisualization.service.js
+++ b/widget/widgetAssets/js/dataVisualization.service.js
@@ -183,6 +183,14 @@
                     break;
                 case dataVisualization_VIZ_MAP_TYPES.HEAT_MAP:
                     {
+                        let yAxisSortingAdded = false;
+                        if ([config.heatMap.xAxis.field.type, config.heatMap.yAxis.field.type].indexOf('datetime') === 1) {
+                            queryObject.sort.push({
+                                field: config.heatMap.yAxis.field.name,
+                                direction: 'ASC'
+                            });
+                            yAxisSortingAdded = true;
+                        }
                         if (['picklist'].indexOf(config.heatMap.xAxis.field.type) > -1) {
                             queryObject.sort.push({
                                 field: config.heatMap.xAxis.field.name + '.orderIndex',
@@ -193,7 +201,13 @@
                                 alias: 'orderIndex',
                                 field: config.heatMap.xAxis.field.name + '.orderIndex'
                             });
-                        } else if (['picklist'].indexOf(config.heatMap.yAxis.field.type) > -1) {
+                        } else {
+                            queryObject.sort.push({
+                                field: config.heatMap.xAxis.field.name,
+                                direction: 'ASC'
+                            });
+                        } 
+                        if (['picklist'].indexOf(config.heatMap.yAxis.field.type) > -1) {
                             queryObject.sort.push({
                                 field: config.heatMap.yAxis.field.name + '.orderIndex',
                                 direction: 'ASC'
@@ -202,6 +216,11 @@
                                 operator: 'groupby',
                                 alias: 'orderIndex',
                                 field: config.heatMap.yAxis.field.name + '.orderIndex'
+                            });
+                        } else if (!yAxisSortingAdded) {
+                            queryObject.sort.push({
+                                field: config.heatMap.yAxis.field.name,
+                                direction: 'ASC'
                             });
                         }
                         queryObject.aggregates.push({

--- a/widget/widgetAssets/js/dataVisualization.service.js
+++ b/widget/widgetAssets/js/dataVisualization.service.js
@@ -183,13 +183,17 @@
                     break;
                 case dataVisualization_VIZ_MAP_TYPES.HEAT_MAP:
                     {
-                        let yAxisSortingAdded = false;
-                        if ([config.heatMap.xAxis.field.type, config.heatMap.yAxis.field.type].indexOf('datetime') === 1) {
+                        if (['datetime'].indexOf(config.heatMap.xAxis.field.type) > -1) {
+                            queryObject.sort.push({
+                                field: config.heatMap.xAxis.field.name,
+                                direction: 'ASC'
+                            });
+                        } 
+                        if (['datetime'].indexOf(config.heatMap.yAxis.field.type) > -1) {
                             queryObject.sort.push({
                                 field: config.heatMap.yAxis.field.name,
                                 direction: 'ASC'
                             });
-                            yAxisSortingAdded = true;
                         }
                         if (['picklist'].indexOf(config.heatMap.xAxis.field.type) > -1) {
                             queryObject.sort.push({
@@ -201,13 +205,7 @@
                                 alias: 'orderIndex',
                                 field: config.heatMap.xAxis.field.name + '.orderIndex'
                             });
-                        } else {
-                            queryObject.sort.push({
-                                field: config.heatMap.xAxis.field.name,
-                                direction: 'ASC'
-                            });
-                        } 
-                        if (['picklist'].indexOf(config.heatMap.yAxis.field.type) > -1) {
+                        } else if (['picklist'].indexOf(config.heatMap.yAxis.field.type) > -1) {
                             queryObject.sort.push({
                                 field: config.heatMap.yAxis.field.name + '.orderIndex',
                                 direction: 'ASC'
@@ -216,11 +214,6 @@
                                 operator: 'groupby',
                                 alias: 'orderIndex',
                                 field: config.heatMap.yAxis.field.name + '.orderIndex'
-                            });
-                        } else if (!yAxisSortingAdded) {
-                            queryObject.sort.push({
-                                field: config.heatMap.yAxis.field.name,
-                                direction: 'ASC'
                             });
                         }
                         queryObject.aggregates.push({


### PR DESCRIPTION
## Description:
### Issue:
* Data Visualization (Heatmap): Unsorted datetime field

### Fix:
* Sorted using API sort

### Additional Update:
* Removed title from WordCloud chart 

## Mantis/PMDB:
* Mantis: 1146049
* PMDB: 33958


## Screenshot:
![Screenshot 2025-04-08 at 5 10 50 PM](https://github.com/user-attachments/assets/74fbfbb6-2fa0-486a-858c-76cf3fabbf11)


![Screenshot 2025-04-08 at 5 03 23 PM](https://github.com/user-attachments/assets/4bd93f4b-eea1-4fca-84ff-e6fd7aaaf31e)
